### PR TITLE
54 最後にプレイアブルカードを選択する画面の時にもデッキを確認可能に

### DIFF
--- a/src/app/deck/2pick/components/PlayableCardFinalSelection.tsx
+++ b/src/app/deck/2pick/components/PlayableCardFinalSelection.tsx
@@ -59,8 +59,8 @@ const PlayableCardFinalSelection: React.FC<PlayableCardFinalSelectionProps> = ({
   // カードの表示状態管理
   const [cardsFaceUp, setCardsFaceUp] = useState<boolean[]>([]);
 
+  // 読み込んだ時にカードを表向きにする(0.5秒後に表向きにする)
   useEffect(() => {
-    if (!selectedPlayableCard) {
       // 初期表示時はすべて裏向き
       setCardsFaceUp(new Array(playableChoices.length).fill(false));
 
@@ -70,8 +70,7 @@ const PlayableCardFinalSelection: React.FC<PlayableCardFinalSelectionProps> = ({
       }, 500); // 0.5秒後に表向きにする
 
       return () => clearTimeout(timer);
-    }
-  }, [playableChoices, selectedPlayableCard]);
+  }, [playableChoices]);
 
   return (
     <div className="mt-4 flex flex-col items-center">

--- a/src/app/deck/2pick/components/PlayableCardFinalSelection.tsx
+++ b/src/app/deck/2pick/components/PlayableCardFinalSelection.tsx
@@ -37,6 +37,8 @@ interface PlayableCardFinalSelectionProps {
   onConfirm: () => void;
   /** 戻るボタンがクリックされたときのコールバック関数 */
   onBack: () => void;
+  /** デッキ確認ボタンがクリックされたときのコールバック関数 */
+  onCheckDeck: () => void;
 }
 
 /**
@@ -52,6 +54,7 @@ const PlayableCardFinalSelection: React.FC<PlayableCardFinalSelectionProps> = ({
   isCardDisappearing,
   onConfirm,
   onBack,
+  onCheckDeck,
 }) => {
   // カードの表示状態管理
   const [cardsFaceUp, setCardsFaceUp] = useState<boolean[]>([]);
@@ -91,6 +94,15 @@ const PlayableCardFinalSelection: React.FC<PlayableCardFinalSelectionProps> = ({
                 canShowDetail={false}
               />
             ))}
+          </div>
+          {/* デッキ確認ボタン */}
+          <div className="flex items-center gap-4 mt-4 justify-center">
+          <button
+            className="btn-secondary"
+            onClick={onCheckDeck}
+          >
+            デッキ確認
+          </button>
           </div>
         </div>
       )}

--- a/src/app/deck/2pick/page.tsx
+++ b/src/app/deck/2pick/page.tsx
@@ -390,6 +390,7 @@ export default function TwoPick() {
             isCardDisappearing={isCardDisappearing}
             onConfirm={handlePlayableCardConfirm}
             onBack={() => setSelectedPlayableCard(null)}
+            onCheckDeck={showDeck}
           />
         )}
 


### PR DESCRIPTION
## プレイアブル選択画面の更新
<img width="1094" alt="スクリーンショット 2025-07-03 13 06 22" src="https://github.com/user-attachments/assets/43a56388-2eef-434b-a1a4-073853a624f2" />

- デッキ確認ボタン
- カードの裏表のアニメーション修正